### PR TITLE
Enhance SNMP MIB to support ipAddressIfIndex

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -1,5 +1,6 @@
 import ipaddress
 import python_arptable
+import re
 import socket
 from enum import unique, Enum
 from bisect import bisect_right
@@ -179,15 +180,64 @@ class NextHopUpdater(MIBUpdater):
 
         return self.route_list[right]
 
+
+class IfIndexUpdater(MIBUpdater):
+    def __init__(self):
+        super().__init__()
+        self.db_conn = Namespace.init_namespace_dbs()
+        self.if_index_map = {}
+        self.if_index_list = []
+
+    def _update_if_index_info(self, dev, ip):
+        if ip is None: return
+
+        if_index = mibs.get_index_from_str(dev)
+        if if_index is None: return
+
+        iptuple = ip2byte_tuple(ip)
+        subid = (4,) + iptuple
+        self.if_index_map[subid] = if_index
+        self.if_index_list.append(subid)
+
+    def update_data(self):
+        self.if_index_map = {}
+        self.if_index_list = []
+        interfaces = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "INTF_TABLE:*")
+        for interface in interfaces:
+            ethTablePrefix = re.search(r"INTF_TABLE\:Ethernet[0-9]+\:[0-9.]+", interface)
+            if ethTablePrefix is None:
+                continue
+            else:
+                dev = ethTablePrefix.group().split(':')[1]
+                ip = ethTablePrefix.group().split(':')[2]
+            self._update_if_index_info(dev, ip)
+
+        self.if_index_list.sort()
+
+    def get_if_index(self, sub_id):
+        return self.if_index_map.get(sub_id, None)
+
+    def get_next(self, sub_id):
+        right = bisect_right(self.if_index_list, sub_id)
+        if right >= len(self.if_index_list):
+            return None
+
+        return self.if_index_list[right]
+
+
 class IpMib(metaclass=MIBMeta, prefix='.1.3.6.1.2.1.4'):
     arp_updater = ArpUpdater()
     nexthop_updater = NextHopUpdater()
+    ifindex_updater = IfIndexUpdater()
 
     ipRouteNextHop = \
         SubtreeMIBEntry('21.1.7', nexthop_updater, ValueType.IP_ADDRESS, nexthop_updater.nexthop)
 
     ipNetToMediaPhysAddress = \
         SubtreeMIBEntry('22.1.2', arp_updater, ValueType.OCTET_STRING, arp_updater.arp_dest)
+
+    ipNetToIfIndex = \
+        SubtreeMIBEntry('34.1.3.1', ifindex_updater, ValueType.INTEGER, ifindex_updater.get_if_index)
 
 class InterfacesUpdater(MIBUpdater):
 
@@ -316,7 +366,7 @@ class InterfacesUpdater(MIBUpdater):
         :return: the 0-based interface ID.
         """
         if sub_id:
-            return self.get_oid(sub_id) - 1
+            return self.get_oid(sub_id)
 
     def interface_description(self, sub_id):
         """
@@ -334,7 +384,7 @@ class InterfacesUpdater(MIBUpdater):
         elif oid in self.vlan_oid_name_map:
             return self.vlan_oid_name_map[oid]
 
-        return self.if_alias_map[self.oid_name_map[oid]]
+        return self.oid_name_map[oid]
 
     def _get_counter(self, oid, table_name):
         """
@@ -343,7 +393,7 @@ class InterfacesUpdater(MIBUpdater):
         :return: the counter for the respective sub_id/table.
         """
         # Enum.name or table_name = 'name_of_the_table'
-        # Example: 
+        # Example:
         # table_name = <DbTables.SAI_PORT_STAT_IF_OUT_ERRORS: 20>
         # _table_name = 'SAI_PORT_STAT_IF_OUT_ERRORS'
         _table_name = getattr(table_name, 'name', table_name)
@@ -401,7 +451,7 @@ class InterfacesUpdater(MIBUpdater):
         elif oid in self.oid_lag_name_map:
             counter_value = 0
             # Sum the values of this counter for all ports in the LAG.
-            # Example: 
+            # Example:
             # table_name = <DbTables.SAI_PORT_STAT_IF_OUT_ERRORS: 20>
             # oid = 1001
             # self.oid_lag_name_map = {1001: 'PortChannel01', 1002: 'PortChannel02', 1003: 'PortChannel03'}
@@ -423,14 +473,14 @@ class InterfacesUpdater(MIBUpdater):
             sai_lag_rif_id = self.port_rif_map[sai_lag_id] if sai_lag_id in self.port_rif_map else None
             if sai_lag_rif_id in self.rif_port_map:
                 # Extract the 'name' part of 'table_name'.
-                # Example: 
+                # Example:
                 # table_name = <DbTables.SAI_PORT_STAT_IF_OUT_ERRORS: 20>
                 # _table_name = 'SAI_PORT_STAT_IF_OUT_ERRORS'
                 table_name = getattr(table_name, 'name', table_name)
                 # Find rif counter table if applicable and add the count for this table.
                 # Example:
                 # mibs.RIF_DROPS_AGGR_MAP = {'SAI_PORT_STAT_IF_IN_ERRORS': 'SAI_ROUTER_INTERFACE_STAT_IN_ERROR_PACKETS', 'SAI_PORT_STAT_IF_OUT_ERRORS': 'SAI_ROUTER_INTERFACE_STAT_OUT_ERROR_PACKETS'}
-                # self.rif_counters['6000000000006'] = {'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS': 6, ... 'SAI_ROUTER_INTERFACE_STAT_OUT_ERROR_PACKETS': 6, ...} 
+                # self.rif_counters['6000000000006'] = {'SAI_ROUTER_INTERFACE_STAT_IN_PACKETS': 6, ... 'SAI_ROUTER_INTERFACE_STAT_OUT_ERROR_PACKETS': 6, ...}
                 if table_name in mibs.RIF_DROPS_AGGR_MAP:
                     rif_table_name = mibs.RIF_DROPS_AGGR_MAP[table_name]
                     counter_value += self.rif_counters[sai_lag_rif_id].get(rif_table_name, 0)

--- a/tests/namespace/test_interfaces.py
+++ b/tests/namespace/test_interfaces.py
@@ -5,7 +5,7 @@ import importlib
 # 3 directory levels above sonic-snmpagent/tests/namespace/test_interfaces.py = sonic-snmpagent
 modules_path = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-# Insert sonic-snmpagent and sonic-snmpagent/src to path 
+# Insert sonic-snmpagent and sonic-snmpagent/src to path
 sys.path.insert(0, modules_path)
 sys.path.insert(0, os.path.join(modules_path, 'src'))
 
@@ -51,7 +51,7 @@ class TestGetNextPDU_1213(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 1))))
-        self.assertEqual(value0.data, 0)
+        self.assertEqual(value0.data, 1)
 
     def test_getnextpdu_firstifindex(self):
         # oid.include = 1
@@ -70,7 +70,7 @@ class TestGetNextPDU_1213(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 1))))
-        self.assertEqual(value0.data, 0)
+        self.assertEqual(value0.data, 1)
 
     def test_getnextpdu_secondifindex(self):
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 1))
@@ -88,7 +88,7 @@ class TestGetNextPDU_1213(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 5))))
-        self.assertEqual(value0.data, 4)
+        self.assertEqual(value0.data, 5)
 
     def test_regisiter_response(self):
         mib_2_response = b'\x01\x12\x10\x00\x00\x00\x001\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00,\x01d`\xab\x00\x00\x00\x00\x00\x05\x00\x00\x07\x04\x00\x00\x00\x00\x00\x01\x00\x00\x17\x8b\x00\x00\x00\x03\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\t\x01\x12\x10\x00\x00\x00\x001\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18\x01d`\xab\x00\x00\x00\x00\x00\x05\x00\x00\x02\x02\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02'
@@ -256,7 +256,7 @@ class TestGetNextPDU_1213(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 9000))))
-        self.assertEqual(value0.data, 8999)
+        self.assertEqual(value0.data, 9000)
 
 
     def test_getnextpdu_second_bp_ifindex(self):
@@ -275,7 +275,7 @@ class TestGetNextPDU_1213(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 9024))))
-        self.assertEqual(value0.data, 9023)
+        self.assertEqual(value0.data, 9024)
 
 
     def test_mgmt_iface(self):
@@ -295,7 +295,7 @@ class TestGetNextPDU_1213(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 10001))))
-        self.assertEqual(value0.data, 10000)
+        self.assertEqual(value0.data, 10001)
 
     def test_mgmt_iface_description(self):
         """
@@ -388,7 +388,7 @@ class TestGetNextPDU_1213(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 3000))))
-        self.assertEqual(value0.data, 2999)
+        self.assertEqual(value0.data, 3000)
 
     def test_vlan_iface_description(self):
         """

--- a/tests/test_interfaces.py
+++ b/tests/test_interfaces.py
@@ -46,7 +46,7 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 1))))
-        self.assertEqual(value0.data, 0)
+        self.assertEqual(value0.data, 1)
 
     def test_getnextpdu_firstifindex(self):
         # oid.include = 1
@@ -65,7 +65,7 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 1))))
-        self.assertEqual(value0.data, 0)
+        self.assertEqual(value0.data, 1)
 
     def test_getnextpdu_secondifindex(self):
         oid = ObjectIdentifier(11, 0, 0, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 1))
@@ -83,7 +83,7 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 5))))
-        self.assertEqual(value0.data, 4)
+        self.assertEqual(value0.data, 5)
 
     def test_regisiter_response(self):
         mib_2_response = b'\x01\x12\x10\x00\x00\x00\x001\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00,\x01d`\xab\x00\x00\x00\x00\x00\x05\x00\x00\x07\x04\x00\x00\x00\x00\x00\x01\x00\x00\x17\x8b\x00\x00\x00\x03\x00\x00\x00\n\x00\x00\x00\x01\x00\x00\x00\x02\x00\x00\x00\t\x01\x12\x10\x00\x00\x00\x001\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x18\x01d`\xab\x00\x00\x00\x00\x00\x05\x00\x00\x02\x02\x00\x00\x00\x00\x00\x01\x00\x00\x00\x02'
@@ -252,7 +252,7 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 10001))))
-        self.assertEqual(value0.data, 10000)
+        self.assertEqual(value0.data, 10001)
 
     def test_mgmt_iface_description(self):
         """
@@ -383,7 +383,7 @@ class TestGetNextPDU(TestCase):
         value0 = response.values[0]
         self.assertEqual(value0.type_, ValueType.INTEGER)
         self.assertEqual(str(value0.name), str(ObjectIdentifier(11, 0, 1, 0, (1, 3, 6, 1, 2, 1, 2, 2, 1, 1, 3000))))
-        self.assertEqual(value0.data, 2999)
+        self.assertEqual(value0.data, 3000)
 
     def test_vlan_iface_description(self):
         """
@@ -865,7 +865,7 @@ class TestGetNextPDU_2863(TestCase):
            updater.update_data()
            updater.reinit_data()
            updater.update_data()
-           
+
         # Also load the data for RFC1213 which we will need to check consistency
         importlib.reload(rfc1213)
         cls.lut_1213 = MIBTable(rfc1213.InterfacesMIB)
@@ -955,9 +955,9 @@ class TestGetNextPDU_2863(TestCase):
     def test_vlan_iface_1213_2863_consistent(self):
         """
         Test that the interface paths in RFC1213 and RFC2863 have the same leaf values.
-        """       
-        
-        # Build prefixes for vlan interface descriptions in RFC1213 and RFC2863 tables 
+        """
+
+        # Build prefixes for vlan interface descriptions in RFC1213 and RFC2863 tables
         pfx_1213 = [1, 3, 6, 1, 2, 1, 2, 2, 1, 2]
         pfx_2863 = [1, 3, 6, 1, 2, 1, 31, 1, 1, 1, 18]
 
@@ -968,10 +968,10 @@ class TestGetNextPDU_2863(TestCase):
         raw_oid_2863.append(1)
         incl = 1
         done = False
-        
+
         # Compare actual OIDs found for the two RFCs with the relevant prefix
         while not done:
-            
+
             # Get next OID for each table
             oid_1213 = ObjectIdentifier(11, 0, incl, 0, tuple(raw_oid_1213))
             get_pdu_1213 = GetNextPDU(
@@ -983,7 +983,7 @@ class TestGetNextPDU_2863(TestCase):
                 header=PDUHeader(1, PduTypes.GET, 16, 0, 42, 0, 0, 0),
                 oids=[oid_2863]
             )
-            
+
             # Decode the OIDs found
             encoded_1213 = get_pdu_1213.encode()
             response_1213 = get_pdu_1213.make_response(self.lut_1213)
@@ -991,13 +991,13 @@ class TestGetNextPDU_2863(TestCase):
             response_2863 = get_pdu_2863.make_response(self.lut)
             value0_1213 = response_1213.values[0]
             value0_2863 = response_2863.values[0]
-            
+
             # Convert returned OIDs to lists, and extract prefixes by removing last element
             cur_pfx_1213 = list(value0_1213.name.subids)
             cur_pfx_2863 = list(value0_2863.name.subids)
             cur_pfx_1213.pop()
             cur_pfx_2863.pop()
-            
+
             # Check if the returned OID have the same prefix we started with
             # It may be abbreviated so only check the end
             match_1213 = (cur_pfx_1213 == pfx_1213[-len(cur_pfx_1213):]) and (value0_1213.type_ == ValueType.OCTET_STRING)
@@ -1005,7 +1005,7 @@ class TestGetNextPDU_2863(TestCase):
 
             # We expect both tables to have equal numbers of OIDs
             self.assertEqual(match_1213, match_2863)
-                        
+
             # Check contents if both OIDs still match the original prefix
             if match_1213 and match_2863:
                 last_1213 = value0_1213.name.subids[-1]
@@ -1019,7 +1019,7 @@ class TestGetNextPDU_2863(TestCase):
                 raw_oid_2863 = pfx_2863.copy()
                 raw_oid_2863.append(last_2863)
                 incl = 0
-            
+
             # Otherwise we exhausted the values with this OID prefix
             else:
                 done = True


### PR DESCRIPTION
Sync the code from ec branch to replace value of ipAddressIfIndex (1.3.6.1.2.1.4.34.1.3) in MIB table ipAddressTable (1.3.6.1.2.1.4.34) with interface index (ex: Ethernet0 will be 1).