### PR TITLE
[rfc1213][rfc2863][rfc4292] Improve SNMP agent interface handling

### DIFF
--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -186,6 +186,13 @@ def mgmt_if_entry_table(if_name):
 
     return 'MGMT_PORT|' + if_name
 
+def loopback_if_entry_table(if_name):
+    """
+    :param if_name: given interface to cast
+    :return: MGMT_PORT_TABLE key
+    """
+
+    return 'LOOPBACK_INTERFACE|' + if_name
 
 def mgmt_if_entry_table_state_db(if_name):
     """
@@ -475,6 +482,23 @@ def init_sync_d_queue_tables(db_conn):
 
     return port_queues_map, queue_stat_map, port_queue_list_map
 
+def init_sync_d_loopback_tables(db_conn):
+    # Initializes interface maps for loopback
+    # :return: loopback_oid_name_map
+    oid_name_map = {}
+    db_conn.connect(CONFIG_DB)
+    loopback_intfs_keys = db_conn.keys(CONFIG_DB, loopback_if_entry_table('*'))
+
+    if not loopback_intfs_keys:
+        logger.debug('No loopback interface found in {}'.format(loopback_if_entry_table('')))
+        return {},
+
+    loopback_intfs = [key.split("|")[1] for key in loopback_intfs_keys]
+    oid_name_map = {get_index_from_str(loopback_name): loopback_name for loopback_name in loopback_intfs}
+    logger.debug('Managment port map:\n' + pprint.pformat(oid_name_map, indent=2))
+
+    return oid_name_map,
+
 def get_device_metadata(db_conn):
     """
     :param db_conn: Sonic DB connector
@@ -575,7 +599,7 @@ class Namespace:
         db_conn = []
         Namespace.init_sonic_db_config()
         host_namespace_idx = 0
-        for idx, namespace in enumerate(SonicDBConfig.get_ns_list()): 
+        for idx, namespace in enumerate(SonicDBConfig.get_ns_list()):
             if namespace == multi_asic.DEFAULT_NAMESPACE:
                 host_namespace_idx = idx
             db = SonicV2Connector(use_unix_socket_path=True, namespace=namespace)

--- a/src/sonic_ax_impl/mibs/__init__.py
+++ b/src/sonic_ax_impl/mibs/__init__.py
@@ -194,6 +194,14 @@ def loopback_if_entry_table(if_name):
 
     return 'LOOPBACK_INTERFACE|' + if_name
 
+def intf_table(if_name):
+    """
+    :param if_name: given interface to cast
+    :return: INTF_TABLE key
+    """
+
+    return 'INTF_TABLE:' + if_name
+
 def mgmt_if_entry_table_state_db(if_name):
     """
     :param if_name: given interface to cast

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -22,6 +22,8 @@ from ax_interface.pdu import PDUHeader
 from ax_interface.pdu_implementations import NotifyPDU
 from ax_interface import constants
 
+import psutil
+
 @unique
 class DbTables(int, Enum):
     """
@@ -411,6 +413,8 @@ class InterfacesUpdater(MIBUpdater):
 
         self.namespace_db_map = Namespace.get_namespace_db_map(self.db_conn)
 
+        self.net_if_stats = {}
+
     def reinit_connection(self):
         Namespace.connect_namespace_dbs(self.db_conn)
 
@@ -430,6 +434,7 @@ class InterfacesUpdater(MIBUpdater):
         self.mgmt_oid_name_map, \
         self.mgmt_alias_map = mibs.init_mgmt_interface_tables(self.db_conn[0])
 
+        # Only VLAN interfaces with assigned IP addresses (L3 interfaces) will be retrieved.
         self.vlan_name_map, \
         self.vlan_oid_sai_map, \
         self.vlan_oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_vlan_tables, self.db_conn)
@@ -452,6 +457,9 @@ class InterfacesUpdater(MIBUpdater):
         self.update_rif_counters()
 
         self.aggregate_counters()
+
+        # This is used by the _get_status function to obtain the oper_status of VLAN interfaces.
+        self.net_if_stats = psutil.net_if_stats()
 
         self.if_range = sorted(list(self.oid_name_map.keys()) +
                                list(self.oid_lag_name_map.keys()) +
@@ -718,6 +726,14 @@ class InterfacesUpdater(MIBUpdater):
         # Note: If interface never become up its state won't be reflected in DB entry
         # If state key is not in DB entry assume interface is down
         state = entry.get(key, "down")
+
+        # Note: The VLAN_TABLE in the appldb does not include an oper_status field.
+        # Hence, psutil is used to retrieve interface status from the kernel.
+        if key == "oper_status" and self.get_oid(sub_id) in self.vlan_oid_name_map:
+            vlan_name = self.vlan_oid_name_map[self.get_oid(sub_id)]
+            if vlan_name in self.net_if_stats:
+                interface_stats = self.net_if_stats[vlan_name]
+                state = "up" if interface_stats.isup else "down"
 
         return status_map.get(state, status_map["down"])
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -555,6 +555,8 @@ class InterfacesUpdater(MIBUpdater):
             return self.mgmt_alias_map[self.mgmt_oid_name_map[oid]]
         elif oid in self.vlan_oid_name_map:
             return self.vlan_oid_name_map[oid]
+        elif oid in self.loopback_oid_name_map:
+            return self.loopback_oid_name_map[oid]
 
         return self.oid_name_map[oid]
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -233,15 +233,16 @@ class IfIndexUpdater(MIBUpdater):
         interfaces = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "INTF_TABLE:*")
         loopback_intf_list = set()
         for interface in interfaces:
-            ethTablePrefix = re.search(r"INTF_TABLE\:[A-Za-z]+[0-9]+\:[0-9.\:A-Fa-f]+", interface)
+            ethTablePrefix = re.search(r"INTF_TABLE\:([A-Za-z]+[0-9]+)\:?([0-9.\:A-Fa-f]+)?", interface) # e.g. INTF_TABLE:(Loopback1):(4.4.4.4)/31
             if ethTablePrefix is None:
                 continue
             else:
-                dev = ethTablePrefix.group().split(':')[1]
-                ip = ':'.join(ethTablePrefix.group().split(':')[2:])
+                dev = ethTablePrefix.group(1)
+                ip  = ethTablePrefix.group(2) if ethTablePrefix.group(2) else None
                 if dev.startswith('Loopback'):
-                    loopback_intf_list.add(dev)
-                    # continue
+                    loopback_intf_list.add(dev) # link local address of loopback will be obtained in next section.
+                if ip == None:
+                    continue # if no IP in INTF_TABLE key, skip
             self._update_if_index_info(dev, ip)
 
         # For the Loopback interface, since its link-local address is not recorded in APPLDB, its IP needs to be retrieved separately and updated.
@@ -303,20 +304,36 @@ class NetmaskUpdater(MIBUpdater):
         netip = netip.split('/')[0]
         netiptuple = ip2byte_tuple(netip)
 
-        # Create map beteen subid and OID
-        oid_tuple = (1, 3, 6, 1, 2, 1, 4, 32, 1, 5)
-        self.netmask_map[subid] = oid_tuple + (if_index,) + (ip_type, ip_len,)  + netiptuple + (netmask,)
-        self.netmask_list.append(subid)
+        if subid not in self.netmask_list:
+            # Create map beteen subid and OID
+            oid_tuple = (1, 3, 6, 1, 2, 1, 4, 32, 1, 5)
+            self.netmask_map[subid] = oid_tuple + (if_index,) + (ip_type, ip_len,)  + netiptuple + (netmask,)
+            self.netmask_list.append(subid)
+
+    def _get_net_if_addrs(self):
+        self.net_if_addrs = psutil.net_if_addrs()
 
     def _getIfaceAddress(self, iface):
-        return [ (x.address, x.netmask) if x.family == socket.AddressFamily.AF_INET else (x.address.replace('%{}'.format(iface), ''), x.netmask) for x in psutil.net_if_addrs().get(iface, []) if x.address and (x.family == socket.AddressFamily.AF_INET or x.family == socket.AddressFamily.AF_INET6)]
+        return [ (x.address, x.netmask) if x.family == socket.AddressFamily.AF_INET else (x.address.replace('%{}'.format(iface), ''), x.netmask) for x in self.net_if_addrs.get(iface, []) if x.address and (x.family == socket.AddressFamily.AF_INET or x.family == socket.AddressFamily.AF_INET6)]
 
     def _getIfaceBrdAddress(self, iface):
-        return [ (x.broadcast, x.netmask) if x.family == socket.AddressFamily.AF_INET else (x.broadcast.replace('{}'.format(iface), ''), x.netmask) for x in psutil.net_if_addrs().get(iface, []) if x.broadcast and (x.family == socket.AddressFamily.AF_INET or x.family == socket.AddressFamily.AF_INET6)]
+        return [ (x.broadcast, x.netmask) if x.family == socket.AddressFamily.AF_INET else (x.broadcast.replace('{}'.format(iface), ''), x.netmask) for x in self.net_if_addrs.get(iface, []) if x.broadcast and (x.family == socket.AddressFamily.AF_INET or x.family == socket.AddressFamily.AF_INET6)]
+
+    def _get_ip_mask(self, ip, mask):
+        ipaddr = ipaddress.ip_address(ip)
+        if isinstance(ipaddr, ipaddress.IPv4Address):
+            ip_mask = str(ipaddress.ip_interface('{}/{}'.format(ip, mask)))
+        else:
+            masktuple = ip2byte_tuple(mask)
+            prefix_length = sum(bin(x).count("1") for x in masktuple)
+            ip_mask = str(ipaddress.ip_interface('{}/{}'.format(ip, prefix_length)))
+        return ip_mask
 
     def update_data(self):
         self.netmask_map = {}
         self.netmask_list = []
+        self.net_if_addrs = []
+        self._get_net_if_addrs()
 
         interfaces = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "INTF_TABLE:*")
         for interface in interfaces:
@@ -331,27 +348,28 @@ class NetmaskUpdater(MIBUpdater):
 
         for ip, mask in self._getIfaceAddress('eth0'):
             ipaddr = ipaddress.ip_address(ip)
-
-            if isinstance(ipaddr, ipaddress.IPv4Address):
-                ip_mask = str(ipaddress.ip_interface('{}/{}'.format(ip, mask)))
-            else:
-                masktuple = ip2byte_tuple(mask)
-                prefix_length = sum(bin(x).count("1") for x in masktuple)
-                ip_mask = str(ipaddress.ip_interface('{}/{}'.format(ip, prefix_length)))
-
+            ip_mask = self._get_ip_mask(ip, mask)
             self._update_netmask_info("eth0", ip_mask)
 
         for ip, mask in self._getIfaceAddress('docker0') + self._getIfaceBrdAddress('docker0'):
             ipaddr = ipaddress.ip_address(ip)
-
-            if isinstance(ipaddr, ipaddress.IPv4Address):
-                ip_mask = str(ipaddress.ip_interface('{}/{}'.format(ip, mask)))
-            else:
-                masktuple = ip2byte_tuple(mask)
-                prefix_length = sum(bin(x).count("1") for x in masktuple)
-                ip_mask = str(ipaddress.ip_interface('{}/{}'.format(ip, prefix_length)))
-
+            ip_mask = self._get_ip_mask(ip, mask)
             self._update_netmask_info("docker0", ip_mask)
+
+        # for link local address. If the interface name cannot be converted to an index(mibs.get_index_from_str()), it will be skipped.
+        for iface, snicaddr_list in self.net_if_addrs.items():
+            for snicaddr in snicaddr_list:
+                if snicaddr.family == socket.AddressFamily.AF_INET:
+                    ip = snicaddr.address
+                elif snicaddr.family == socket.AddressFamily.AF_INET6:
+                    ip = snicaddr.address.replace('%{}'.format(iface), '')
+                else:
+                    continue
+                mask = snicaddr.netmask
+                ipaddr = ipaddress.ip_address(ip)
+                if ipaddr.is_link_local:
+                    ip_mask = self._get_ip_mask(ip, mask)
+                    self._update_netmask_info(iface, ip_mask)
 
         self.netmask_list.sort()
 
@@ -401,6 +419,7 @@ class InterfacesUpdater(MIBUpdater):
         self.vlan_name_map = {}
         self.rif_port_map = {}
         self.port_rif_map = {}
+        self.loopback_oid_name_map = {}
 
         # cache of interface counters
         self.if_counters = {}
@@ -447,6 +466,8 @@ class InterfacesUpdater(MIBUpdater):
         self.oid_lag_name_map, \
         self.lag_sai_map, self.sai_lag_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_lag_tables, self.db_conn)
 
+        self.loopback_oid_name_map, = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_loopback_tables, self.db_conn)
+
     def update_data(self):
         """
         Update redis (caches config)
@@ -464,7 +485,8 @@ class InterfacesUpdater(MIBUpdater):
         self.if_range = sorted(list(self.oid_name_map.keys()) +
                                list(self.oid_lag_name_map.keys()) +
                                list(self.mgmt_oid_name_map.keys()) +
-                               list(self.vlan_oid_name_map.keys()))
+                               list(self.vlan_oid_name_map.keys()) +
+                               list(self.loopback_oid_name_map.keys()))
         self.if_range = [(i,) for i in self.if_range]
 
     def update_if_counters(self):

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -93,6 +93,7 @@ class InterfaceMIBUpdater(MIBUpdater):
         self.mgmt_alias_map = {}
         self.vlan_oid_name_map = {}
         self.vlan_name_map = {}
+        self.loopback_oid_name_map = {}
         self.if_counters = {}
         self.if_range = []
         self.if_name_map = {}
@@ -130,10 +131,13 @@ class InterfaceMIBUpdater(MIBUpdater):
         self.vlan_oid_sai_map, \
         self.vlan_oid_name_map = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_vlan_tables, self.db_conn)
 
+        self.loopback_oid_name_map, = Namespace.get_sync_d_from_all_namespace(mibs.init_sync_d_loopback_tables, self.db_conn)
+
         self.if_range = sorted(list(self.oid_name_map.keys()) +
                                list(self.oid_lag_name_map.keys()) +
                                list(self.mgmt_oid_name_map.keys()) +
-                               list(self.vlan_oid_name_map.keys()))
+                               list(self.vlan_oid_name_map.keys()) +
+                               list(self.loopback_oid_name_map.keys()))
         self.if_range = [(i,) for i in self.if_range]
 
     def update_data(self):
@@ -158,7 +162,8 @@ class InterfaceMIBUpdater(MIBUpdater):
         self.if_range = sorted(list(self.oid_name_map.keys()) +
                                list(self.oid_lag_name_map.keys()) +
                                list(self.mgmt_oid_name_map.keys()) +
-                               list(self.vlan_oid_name_map.keys()))
+                               list(self.vlan_oid_name_map.keys()) +
+                               list(self.loopback_oid_name_map.keys()))
         self.if_range = [(i,) for i in self.if_range]
 
     def get_next(self, sub_id):
@@ -289,6 +294,8 @@ class InterfaceMIBUpdater(MIBUpdater):
             if_table = mibs.vlan_entry_table(self.vlan_oid_name_map[oid])
         elif oid in self.oid_name_map:
             if_table = mibs.if_entry_table(self.oid_name_map[oid])
+        elif oid in self.loopback_oid_name_map:
+            if_table = mibs.intf_table(self.loopback_oid_name_map[oid])
         else:
             return None
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc2863.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc2863.py
@@ -201,6 +201,8 @@ class InterfaceMIBUpdater(MIBUpdater):
             result = self.mgmt_alias_map[self.mgmt_oid_name_map[oid]]
         elif oid in self.vlan_oid_name_map:
             result = self.vlan_oid_name_map[oid]
+        elif oid in self.loopback_oid_name_map:
+            return self.loopback_oid_name_map[oid]
         else:
             result = self.oid_name_map[oid]
 

--- a/src/sonic_ax_impl/mibs/ietf/rfc4292.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc4292.py
@@ -82,7 +82,7 @@ class RouteUpdater(MIBUpdater):
                 ## Ignore non front panel interfaces
                 ## TODO: non front panel interfaces should not be in APPL_DB at very beginning
                 ## This is to workaround the bug in current sonic-swss implementation
-                if ifn == "eth0" or ifn == "lo" or ifn == "docker0":
+                if ifn == "eth0" or ifn == "lo" or ifn == "docker0" or ifn.startswith("eth0."):
                     continue
 
                 # Ignore internal asic routes

--- a/tests/test_rfc1213.py
+++ b/tests/test_rfc1213.py
@@ -94,9 +94,12 @@ class TestNextHopUpdaterRedisException(TestCase):
 
             if per_namespace_func == sonic_ax_impl.mibs.init_sync_d_rif_tables:
                 return [{}, {}]
-            
+
+            if per_namespace_func == sonic_ax_impl.mibs.init_sync_d_loopback_tables:
+                return [{}]
+
             return [{}, {}, {}, {}, {}]
-        
+
         updater = InterfacesUpdater()
         with mock.patch('sonic_ax_impl.mibs.Namespace.get_sync_d_from_all_namespace', mock_get_sync_d_from_all_namespace):
             with mock.patch('sonic_ax_impl.mibs.Namespace.connect_namespace_dbs') as connect_namespace_dbs:

--- a/tests/test_rfc2863.py
+++ b/tests/test_rfc2863.py
@@ -29,6 +29,9 @@ class TestInterfaceMIBUpdater(TestCase):
                     {},
                     {121: 'Ethernet120'}]
 
+        if per_namespace_func == sonic_ax_impl.mibs.init_sync_d_loopback_tables:
+            return [{}]
+
         return [{},{},{}]
 
     def mock_lag_entry_table(lag_name):


### PR DESCRIPTION
This PR includes the following improvements:

1. Fixed Loopback interface indexing and link-local address handling:
   - Added loopback_if_entry_table() and init_sync_d_loopback_tables() functions
   - Fixed handling for IF-MIB::ifIndex and IP-MIB::ipAddressIfIndex/Prefix objects

2. Ignored tagged management ports as non-frontpanel interfaces:
   - Extended filtering conditions to include interfaces starting with "eth0."

These improvements enable the SNMP agent to properly handle Loopback interfaces and tagged management ports, enhancing the accuracy and consistency of MIB queries.
