### PR TITLE
Fix parsing of subport interfaces in IP-MIB::ipAddressIfIndex

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -233,7 +233,7 @@ class IfIndexUpdater(MIBUpdater):
         interfaces = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "INTF_TABLE:*")
         loopback_intf_list = set()
         for interface in interfaces:
-            ethTablePrefix = re.search(r"INTF_TABLE\:([A-Za-z]+[0-9]+)\:?([0-9.\:A-Fa-f]+)?", interface) # e.g. INTF_TABLE:(Loopback1):(4.4.4.4)/31
+            ethTablePrefix = re.search(r"INTF_TABLE\:([A-Za-z]+[0-9.]*)\:?([0-9.\:A-Fa-f]+)?", interface) # e.g. INTF_TABLE:(Loopback1):(4.4.4.4)/31
             if ethTablePrefix is None:
                 continue
             else:
@@ -337,7 +337,7 @@ class NetmaskUpdater(MIBUpdater):
 
         interfaces = Namespace.dbs_keys(self.db_conn, mibs.APPL_DB, "INTF_TABLE:*")
         for interface in interfaces:
-            ethTablePrefix = re.search(r"INTF_TABLE\:[A-Za-z]+[0-9]+\:[0-9.\:A-Fa-f]+/[0-9]+", interface)
+            ethTablePrefix = re.search(r"INTF_TABLE\:[A-Za-z]+[0-9.]*\:[0-9.\:A-Fa-f]+/[0-9]+", interface)
             if ethTablePrefix is None:
                 continue
             else:


### PR DESCRIPTION
#### Why I did it
The regular expression used for APPL_DB's INTF_TABLE fails to correctly parse subport interfaces.
For example, the regex incorrectly extracts the IP address from `INTF_TABLE:Ethernet1.10:4.4.4.1/32` as `.10:4.4.4.1` instead of the correct value.