### PR TITLE
Fix portchannel get No more variables left in this MIB View

### DIFF
--- a/src/sonic_ax_impl/mibs/ietf/rfc1213.py
+++ b/src/sonic_ax_impl/mibs/ietf/rfc1213.py
@@ -696,6 +696,8 @@ class InterfacesUpdater(MIBUpdater):
             if_table = mibs.vlan_entry_table(self.vlan_oid_name_map[oid])
         elif oid in self.oid_name_map:
             if_table = mibs.if_entry_table(self.oid_name_map[oid])
+        elif oid in self.loopback_oid_name_map:
+            if_table = mibs.intf_table(self.loopback_oid_name_map[oid])
         else:
             return None
 


### PR DESCRIPTION
#### Why I did it
Snmp can not get portchannel data normally

#### How I did it
Missing loopback option for getting interface items
causes the previous interface to return incorrect value,
Added loopback option to fix it.

#### How to verify it